### PR TITLE
Improve text readability on widescreen displays

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,7 +5,7 @@ import ModeToggle from "../components/mode-toggle";
 
 <Layout>
   <div
-    class="prose prose-slate dark:prose-invert prose-p:indent-4 prose-p:text-base sm:prose-p:text-lg md:prose-p:text-xl lg:prose-p:text-2xl xl:prose-p:text-3xl mx-auto my-6 w-full max-w-prose px-6 text-justify font-extralight text-balance hyphens-manual sm:max-w-2xl sm:px-8 md:my-8 md:max-w-3xl lg:my-20 lg:max-w-4xl lg:px-6 xl:my-16 xl:max-w-6xl xl:px-4"
+    class="prose prose-slate dark:prose-invert prose-p:indent-4 prose-p:text-base sm:prose-p:text-lg md:prose-p:text-xl lg:prose-p:text-2xl xl:prose-p:text-xl mx-auto my-6 w-full max-w-prose px-6 text-justify font-extralight text-balance hyphens-manual sm:max-w-2xl sm:px-8 md:my-8 md:max-w-3xl lg:my-20 lg:max-w-4xl lg:px-6 xl:my-16 xl:max-w-4xl xl:px-4"
   >
     <div class="flex flex-col gap-4 tracking-[0.2em]">
       <h1


### PR DESCRIPTION
…eadability

- Cap max-width at xl:max-w-4xl (896px) instead of xl:max-w-6xl (1152px)
- Reduce text size from xl:prose-p:text-3xl to xl:prose-p:text-xl
- Maintains optimal line length (60-80 chars) for comfortable reading
- Prevents text from becoming uncomfortably large on wide displays